### PR TITLE
Fix using bare variables

### DIFF
--- a/tasks/deploy.yml
+++ b/tasks/deploy.yml
@@ -4,6 +4,6 @@
   template:
     src: reverse-proxy.conf.j2
     dest: "{{ nginx_reverse_proxy_config_directory }}/{{ item.config_name }}.conf"
-  with_items: nginx_reverse_proxy_proxies
+  with_items: "{{ nginx_reverse_proxy_proxies }}"
   notify:
     - restart nginx


### PR DESCRIPTION
[DEPRECATION WARNING]: Using bare variables is deprecated. Update your 
playbooks so that the environment value uses the full variable syntax 
('{{nginx_reverse_proxy_proxies}}').
This feature will be removed in a future